### PR TITLE
No more PlayFabId on skin and Fix player can't download server packs

### DIFF
--- a/src/pocketmine/entity/Human.php
+++ b/src/pocketmine/entity/Human.php
@@ -123,7 +123,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 	protected static function deserializeSkinNBT(CompoundTag $skinTag) : Skin{
 		$skin = new Skin(
 			$skinTag->getString("Name"),
-			$skinTag->getString("PlayFabId", ""),
 			$skinTag->hasTag("Data", StringTag::class) ? $skinTag->getString("Data") : $skinTag->getByteArray("Data"), //old data (this used to be saved as a StringTag in older versions of PM)
 			$skinTag->getByteArray("CapeData", ""),
 			$skinTag->getString("GeometryName", ""),
@@ -781,7 +780,6 @@ class Human extends Creature implements ProjectileSource, InventoryHolder{
 		if($this->skin !== null){
 			$this->namedtag->setTag(new CompoundTag("Skin", [
 				new StringTag("Name", $this->skin->getSkinId()),
-				new StringTag("PlayFabId", $this->skin->getPlayFabId()),
 				new ByteArrayTag("Data", $this->skin->getSkinData()),
 				new ByteArrayTag("CapeData", $this->skin->getCapeData()),
 				new StringTag("GeometryName", $this->skin->getGeometryName()),

--- a/src/pocketmine/entity/Skin.php
+++ b/src/pocketmine/entity/Skin.php
@@ -39,8 +39,6 @@ class Skin{
 	/** @var string */
 	private $skinId;
 	/** @var string */
-	private $playFabId;
-	/** @var string */
 	private $skinData;
 	/** @var string */
 	private $capeData;
@@ -49,9 +47,8 @@ class Skin{
 	/** @var string */
 	private $geometryData;
 
-	public function __construct(string $skinId, string $playFabId, string $skinData, string $capeData = "", string $geometryName = "", string $geometryData = ""){
+	public function __construct(string $skinId, string $skinData, string $capeData = "", string $geometryName = "", string $geometryData = ""){
 		$this->skinId = $skinId;
-		$this->playFabId = $playFabId;
 		$this->skinData = $skinData;
 		$this->capeData = $capeData;
 		$this->geometryName = $geometryName;
@@ -89,10 +86,6 @@ class Skin{
 
 	public function getSkinId() : string{
 		return $this->skinId;
-	}
-
-	public function getPlayFabId(): string {
-		return $this->playFabId;
 	}
 
 	public function getSkinData() : string{

--- a/src/pocketmine/level/particle/FloatingTextParticle.php
+++ b/src/pocketmine/level/particle/FloatingTextParticle.php
@@ -97,7 +97,7 @@ class FloatingTextParticle extends Particle{
 
 			$add = new PlayerListPacket();
 			$add->type = PlayerListPacket::TYPE_ADD;
-			$add->entries = [PlayerListEntry::createAdditionEntry($uuid, $this->entityId, $name, SkinAdapterSingleton::get()->toSkinData(new Skin("Standard_Custom", "", str_repeat("\x00", 8192))))];
+			$add->entries = [PlayerListEntry::createAdditionEntry($uuid, $this->entityId, $name, SkinAdapterSingleton::get()->toSkinData(new Skin("Standard_Custom", str_repeat("\x00", 8192))))];
 			$p[] = $add;
 
 			$pk = new AddPlayerPacket();

--- a/src/pocketmine/network/mcpe/NetworkBinaryStream.php
+++ b/src/pocketmine/network/mcpe/NetworkBinaryStream.php
@@ -99,7 +99,7 @@ class NetworkBinaryStream extends BinaryStream{
 
 	public function getSkin() : SkinData{
 		$skinId = $this->getString();
-		$playFabId = "";
+		$playFabId = '';
 		if($this->protocol >= BedrockProtocolInfo::PROTOCOL_1_16_210){
 			$playFabId = $this->getString();
 		}
@@ -161,7 +161,7 @@ class NetworkBinaryStream extends BinaryStream{
 	public function putSkin(SkinData $skin){
 		$this->putString($skin->getSkinId());
 		if($this->protocol >= BedrockProtocolInfo::PROTOCOL_1_16_210){
-			$this->putString($skin->getPlayFabId() ?? "");
+			$this->putString($skin->getPlayFabId() ?? '');
 		}
 		$this->putString($skin->getResourcePatch());
 		$this->putSkinImage($skin->getSkinImage());

--- a/src/pocketmine/network/mcpe/protocol/BedrockProtocolInfo.php
+++ b/src/pocketmine/network/mcpe/protocol/BedrockProtocolInfo.php
@@ -13,7 +13,10 @@ final class BedrockProtocolInfo {
 	public const PROTOCOL_1_16_220 = 431;
 
 	public static function translateProtocol(int $protocol) : int {
-		if (in_array($protocol, [414, 415, 416, 417, 418, 419, 420, 421, 422], true)) {
+		if (in_array($protocol, [414, 415, 416, 417, 418, 419], true)) {
+			return BedrockProtocolInfo::PROTOCOL_1_16_100;
+		}		
+		if (in_array($protocol, [420, 421, 422], true)) {
 			return BedrockProtocolInfo::PROTOCOL_1_16_200;
 		}
 		if (in_array($protocol, [423, 424, 425, 426, 427, 428], true)) {

--- a/src/pocketmine/network/mcpe/protocol/types/LegacySkinAdapter.php
+++ b/src/pocketmine/network/mcpe/protocol/types/LegacySkinAdapter.php
@@ -44,7 +44,7 @@ class LegacySkinAdapter implements SkinAdapter{
 		}
 		return new SkinData(
 			$skin->getSkinId(),
-			$skin->getPlayFabId(),
+			'',
 			json_encode(["geometry" => ["default" => $geometryName]]),
 			SkinImage::fromLegacy($skin->getSkinData()), [],
 			$capeImage,
@@ -54,7 +54,7 @@ class LegacySkinAdapter implements SkinAdapter{
 
 	public function fromSkinData(SkinData $data) : Skin{
 		if($data->isPersona()){
-			return new Skin("Standard_Custom", $data->getPlayFabId(), str_repeat(random_bytes(3) . "\xff", 2048));
+			return new Skin("Standard_Custom", str_repeat(random_bytes(3) . "\xff", 2048));
 		}
 
 		$capeData = $data->isPersonaCapeOnClassic() ? "" : $data->getCapeImage()->getData();
@@ -66,6 +66,6 @@ class LegacySkinAdapter implements SkinAdapter{
 			throw new InvalidSkinException("Missing geometry name field");
 		}
 
-		return new Skin($data->getSkinId(), $data->getPlayFabId(), $data->getSkinImage()->getData(), $capeData, $geometryName, $data->getGeometryData());
+		return new Skin($data->getSkinId(), $data->getSkinImage()->getData(), $capeData, $geometryName, $data->getGeometryData());
 	}
 }


### PR DESCRIPTION
## Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Don't need to fill PlayFabId on Skin construct and Fix 1.16.100 player can't download server packs

### Relevant issues
<!-- List relevant issues here -->
- The old one needs to fill PlayFabId on Skin construct
  So it will break some plugin like cosmetic
- Fix for 1.16.100 player can't download server packs

## Changes
- Remove playfabid on skin
- Update translateProtocol function
### API changes
<!-- Any additions to the API that should be documented in release notes? -->
Nothing

### Behavioural changes
<!-- Any change in how the server behaves, or its performance? -->
- Can create Skin construct without PlayFabId
- 1.16.100 Player can download server packs

## Backwards compatibility
<!-- Any possible backwards incompatible changes? How are they solved, or how can they be solved? -->
Nothing

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
Nothing

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result
-->
I have confirmed that players can log in normally.
I have confirmed that players can change skin normally.
